### PR TITLE
Update 1. Phantom Star 幻影星.md

### DIFF
--- a/Myriad Worlds/Cloud Abyss Star Domain/1. Phantom Star 幻影星.md
+++ b/Myriad Worlds/Cloud Abyss Star Domain/1. Phantom Star 幻影星.md
@@ -3,42 +3,45 @@
   <img src="https://github.com/BRC1024Rootverse/Rootverse/assets/170728893/2f0f4701-c87e-42c0-8307-394263b8d0d7" width="550" />
 
 ## Phantom Star
-- **Star Magic Tower**: An ancient magic tower on an island, serving as an academy and laboratory for magicians, filled with secrets and treasures of star magic.
-- **Misttalk Forest**: Located in the western part of the planet, this vibrant cloud-top forest's every leaf is imbued with life through magic, capable of telling stories of the past and prophecies of the future, representing the memory and wisdom of history.
-- **Moonlight Sea**: The waters here are silver-white, said to enhance magical energy when immersed.
+-Phantom Star is a magical planet in the Cloud Abyss Star Domain, inhabited by both the Magic Clan and the Night Shadow Clan. The planet is shrouded in misty magic fog, exuding mysterious and powerful magic.
+- **Star Magic Tower**: The towering Star Magic Tower is located on the Phantom Star, standing like a pillar in the sky. This ancient magic tower is the academy and laboratory of magicians, and contains countless rare magic knowledge and treasures. Whenever night falls, the top of the tower will emit a dazzling magic light, illuminating the entire planet. It is said that only through complex star magic rituals can one enter the tower to explore the hidden secrets.
+- **Misttalk Forest**:The Whispering Mist Forest in the west of Phantom Star is full of vitality and shrouded in magic. Every leaf seems to have its own voice, telling stories of the past and prophecies of the future. The forest is filled with the breath of magic, and occasionally you can see magical creatures shuttling through the woods. Some people say that only by listening to the whispers of the forest can you understand true wisdom.
+- **Moonlight Sea**: The Moonlight Sea, located in the east of the planet, has a mirror-like surface and emits a silvery-white luster. It is said that soaking in the Moonlight Sea can greatly enhance magical energy. Magical moonlight creatures often emerge from the sea, and they have powerful magical powers. Some brave magicians will dive into the Moonlight Sea to look for rare magical treasures.
 - **Core of Magic Temple**: Built on a huge floating rock, it houses a vast collection of magical knowledge and artifacts, making it a sacred place for the Magic Clan.
 - **Mirror Sea**: A vast water body with a surface as reflective as a mirror, perfectly mirroring the floating islands above. The aquatic life in the pool possesses magical properties, particularly magical pearls that can reflect one's true spirit. The calm waters reflect the beauty of the cloud dynasty perfectly. It is said that the sea contains precious magical pearls that reveal the true nature of the heart.
-- **Phantom City**: The heart of the planet, a large city composed of floating islands connected by magical bridges, the entire city spins like a disc in the starry sky.
-- **Valley of Heavenly Sounds**: Located in the northern part of the planet, this deep valley's stones emit melodic sounds due to special magic. When the wind blows, the entire valley becomes a giant musical instrument, producing celestial sounds.
-- **Shadow City**: Built on a dark island, the city's buildings are black or deep blue. The Shadow Clan excels in stealth and concealment, so the city's architecture is designed to be very secretive and mysterious.
-- **Nightshadow Canyon**: Deep within the canyon where sunlight rarely reaches is the dwelling place of the Shadow Clan. The rocks in the canyon are inscribed with ancient magical runes that emit a soft blue glow at night.
+- **Phantom City**: The heart of Phantom Star is a metropolis made up of countless floating islands. Each island is connected by a magic bridge, and the entire city is like a huge plate spinning in the starry sky. The city buildings are of various shapes and exude a strong magical atmosphere. Here, the magic tribe and the night shadow tribe live in harmony, jointly maintaining this fairyland-like planet.
+- **Valley of Heavenly Sounds**:Tianyin Valley, located in the north of the planet, is a deep canyon where the stones can emit melodious music due to special magic. When the wind blows, the entire canyon will become a huge musical instrument, playing beautiful natural sounds. Many magicians come here to practice and listen to the songs of nature in the hope of gaining inspiration.
+- **Shadow City**: The Shadow City is built on a dark island and is inhabited by the Night Shadow Clan. Most of the city buildings are black or dark blue, giving people a mysterious and gloomy feeling. This is the main residence of the Night Shadow Clan. They are good at sneaking and hiding, and the city's buildings are also designed to be very secretive. Here, the Night Shadow Clan masters the magic of hiding and illusion, and can move freely in the dark.
+- **Nightshadow Canyon**: The Night Shadow Canyon, located deep in Shadow City, never sees sunlight all year round and is the main residence of the Night Shadow Clan. The rocks in the canyon are engraved with ancient magic runes, which emit a faint blue light at night. Here, the Night Shadow Clan masters the mysterious shadow magic and can move freely in the dark. Some people say that only by truly understanding the nature of darkness can one master the power of the Night Shadow Clan.
 
 
 
 ## 幻影星
+幻影星是雲淵星域中的一颗神奇星球,被魔法族和夜影族共同居住。这颗星球笼罩在迷蒙的魔法雾气之中,散发着神秘而又强大的魔力。
+
 ### 星法塔
-島嶼上矗立著古老的魔法塔，是星球上魔法師的學院和實驗室，裡面充滿了星法的秘密與寶藏。
+高耸入云的星法塔坐落在幻影星上,矗立如苍天之柱。这座古老的魔法塔是魔法师们的学院和实验室,内藏了无数稀有的魔法知识和宝藏。每当夜幕降临,塔顶便会发出耀眼的魔法光芒,照耀整个星球。据说,只有通过复杂的星法仪式,才能进入塔中探寻隐藏的秘密。
 
 ### 霧語森林
-星球的西部，是一片生機勃勃的雲上森林。這片森林的每一片葉子都被魔法賦予了生命，它們能夠訴說過去的故事和未來的預言，代表歷史的記憶與智慧。
+幻影星西部的雾语森林生机勃勃,被魔法所笼罩。每一片树叶都似乎拥有自己的声音,述说着过去的故事和未来的预言。森林中飘荡着魔法的气息,偶尔还能看到神奇的生物在林间穿梭。有人说,只有倾听森林的呢喃,才能领悟到真正的智慧。
 
 ### 月光海
-此海域的水呈現出銀白色，據說浸泡其中可以增強魔法能量。
+位于星球东部的月光海,水面如镜,散发着银白的光泽。据说,浸泡在月光海中可以大幅增强魔法能量。海中时常浮现出神奇的月光生物,它们拥有强大的魔法力量。有些勇敢的魔法师会潜入月光海,寻找稀有的魔法珍宝。
 
 ### 魔核神殿
-建於一個巨大的漂浮石上，內部藏有大量的魔法知識和神器，是魔法族的聖地。
+矗立在一座巨大漂浮石上的魔核神殿,是幻影星上最神圣的地方。神殿内部藏有大量的魔法知识和神器,是魔法族的圣地。只有通过漫长的修行和仪式,才能进入神殿,一窥其中的奥秘。据说,神殿中央的魔核蕴含着星球全部的魔法力量。
 
 ### 天鏡之海
-是一個巨大的水域，水面如鏡，完美反射著浮游島嶼的影子。池中的水生生物都有神奇的魔法力量，尤其是能夠映照心靈的魔法珍珠。這片海域的水面平靜如鏡，能完美反射雲端王朝的美景。傳說中，海中有一種珍貴的魔法珍珠，能夠映照出真實的心靈。
+这片广阔的水域如同一面巨大的镜子,能完美地反射浮游岛屿的倒影。海中的神奇生物都拥有独特的魔法力量,尤其是那种能映照心灵的魔法珍珠。有传言说,曾有人在这片海中看到了自己内心最真实的模样。
 
 ### 幻影都市
-星球的心臟地帶，是由浮游島嶼組成的大都市，每個島嶼都由魔法橋樑連接，整座城市如同一個在星空中旋轉的盤子。
+幻影星的心脏地带,是一座由无数浮游岛屿组成的大都市。每个岛屿都由魔法桥梁相连,整座城市如同一个在星空中旋转的巨大盘子。城市建筑物形态各异,散发着强大的魔法气息。在这里,魔法族和夜影族和谐共处,共同维系着这片仙境般的星球。
 
 ### 天音谷
-在星球的北方，是一片深邃的峽谷，裡面的石頭都因為特殊的魔法而能發出悠揚的旋律。當風吹過時，整個峽谷都會變成一個巨大的樂器，發出天籟之音。
+位于星球北部的天音谷是一处深邃的峡谷,里面的石头都因特殊的魔法而能发出悠扬的旋律。当风吹过时,整个峡谷都会变成一件巨大的乐器,奏响动听的天籁之音。有不少魔法师会来到这里修行,聆听大自然的歌声,以期获得灵感。
 
 ### 暗影城
-建在一個黑暗的島上，城市中的建築都是黑色或者深藍色，夜影族善於潛行和潛藏，所以城市的建築都設計得非常隱秘和神秘。
+建在一座黑暗岛屿上的暗影城,被夜影族所居住。城市建筑物大多为黑色或深蓝色,给人一种神秘阴郁的感觉。这里是夜影族的主要居所,他们善于潜行隐匿,城市的建筑也都设计得十分隐秘。在这里,夜影族掌握着隐藏和幻象的魔法,能在黑暗中自由穿梭。
 
 ### 夜影峽谷
-峽谷深處常年不見陽光，是夜影族的居住地。峽谷中的岩石刻有古老的魔法符文，夜晚時，這些符文會發出幽藍的光芒。
+位于暗影城深处的夜影峡谷终年不见阳光,是夜影族最主要的居住地。峡谷中的岩石刻有古老的魔法符文,在夜晚发出幽蓝的光芒。在这里,夜影族掌握着神秘莫测的暗影魔法,能在黑暗中自由行动。有人说,只有真正了解黑暗的本质,才能掌握夜影族的力量。


### PR DESCRIPTION
Phantom Star is a magical planet in the Cloud Abyss Star Domain, inhabited by both the Magic Clan and the Night Shadow Clan. The planet is shrouded in misty magic fog, exuding mysterious and powerful magic. 幻影星是雲淵星域中的一颗神奇星球,被魔法族和夜影族共同居住。这颗星球笼罩在迷蒙的魔法雾气之中,散发着神秘而又强大的魔力。