### PR TITLE
Update 1. War God Star 戰神星.md

### DIFF
--- a/Divine Realm/Oracle Realm/1. War God Star 戰神星.md
+++ b/Divine Realm/Oracle Realm/1. War God Star 戰神星.md
@@ -3,29 +3,41 @@
   <img src="https://github.com/BRC1024Rootverse/Rootverse/assets/170728893/afb8d2e7-c7d2-4303-b73e-6760ec328fa8" width="550" />
 
 ### War God Star
-War God Star is a planet teeming with battlefields and arenas, perfectly suited for the combat training and martial testing of the Warrior Clan. The Warrior Clan practices their combat skills here, and at the center of the planet stands a colossal Temple of War, which serves as the gathering and decision-making center for the clan.
-- **War God Plains**: The War God Plains are the most expansive area on War God Star, filled with battlefields for training and live combat exercises. The terrain varies greatly, from ravines to hills, providing a diverse training environment for the Warrior Clan. This site frequently hosts large-scale combat simulations, attracting numerous warriors to hone their skills.
-- **Eternal Arena**: Located at the center of the planet, this massive open-air arena can accommodate tens of thousands of spectators. The arena hosts various significant fights and competitions, including the annual Warrior Clan Championships and the War God Ceremony.
-- **Temple of War**: Adjacent to the arena stands the Temple of War, the spiritual and command center of the Warrior Clan. The interior of the temple is adorned with statues and murals of war gods from various eras, documenting the history and honors of combat.
-- **Ironblood Village**: Scattered around the War God Plains are small villages, primarily inhabited by warriors engaged in daily training and their families. These villages are robustly constructed to withstand potential accidental impacts during training.
-- **Weapons Forge Area**: In the western part of War God Star, there is a specialized area dedicated to the manufacture and testing of new weapons. This area attracts the universe’s finest blacksmiths and weapon masters, continuously providing the most advanced combat equipment to the Warrior Clan.
+War God Star is one of the four major planets in the Oracle Realm, renowned for its environment brimming with combat and martial testing. This planet serves as the primary training ground and residence for the Divine Warrior Clan, but it also attracts Male Gods and Goddesses for various martial training and spiritual cultivation. War God Star is not only a forge for combat skills but also a stage where deities display their power and glory. Compared to the other three planets (Destiny Wheel Star, Veiled Origin Star, Sanctuary of Return), War God Star emphasizes practical combat and martial prowess, while the other planets focus on destiny analysis, mysterious exploration, and soul restoration, respectively.
+In the ancient times of the Oracle Realm, the Male Gods, Goddesses, and Divine Warriors united to fend off dark forces from the void. In that epic battle, War God Star became the central battlefield. Legend has it that Ares, the war god of the Male Gods, and Athena, the war goddess of the Goddesses, joined forces with Leo, the leader of the Divine Warriors, to finally defeat the dark forces and protect the peace of the Oracle Realm. To commemorate this great victory, the three races decided to make War God Star an eternal training ground and a sacred site of war.
+- **War God Plains**: The War God Plains are the most expansive area on War God Star, filled with various training and live combat fields. The terrain here is incredibly diverse, ranging from deep ravines to towering hills, providing a rich variety of training environments for the Divine Warriors. According to legend, the war gods of the Male Gods and Goddesses left countless battle marks here. Every rock and river has witnessed their bravery and wisdom.
+  In the center of the War God Plains, there is a vast battlefield with ancient runes etched into the ground. These runes are said to be the spells used by the war gods in their battles. Whenever the moonlight shines, these runes emit a faint glow, as if telling those ancient stories. Statues of war gods stand on the surrounding hills, as if guarding this sacred land.
+- **Eternal Arena**: The Eternal Arena is located at the center of War God Star, a massive open-air arena that can accommodate tens of thousands of spectators. It is the venue for various significant battles and competitions, including the annual Divine Warrior Championships and the War God Ceremony. Each year, warriors from different races gather here to showcase their combat skills and strength.
+The center of the arena is a vast expanse of sand, surrounded by towering stands. Whenever a competition begins, the spectators on the stands cheer and shout, filling the entire arena with an atmosphere of tension and excitement. The walls of the arena are inlaid with countless gems, which sparkle in the sunlight, as if adding a mysterious power to each battle.
+- **Temple of War**: The Temple of War stands adjacent to the Eternal Arena and serves as the spiritual and command center of the Divine Warrior Clan. The interior of the temple is adorned with statues and murals of war gods from various eras, documenting the history and honors of combat. It is also the place where the Divine Warrior Clan makes major decisions and conducts sacrificial ceremonies.
+The interior of the temple is spacious and sacred, with a colossal altar at the center, engraved with ancient runes and symbols of the war gods. The surrounding walls are adorned with vivid murals depicting the heroic deeds of the war gods, each painting vividly showcasing their courage and wisdom. The dome of the temple is made of pure gold, sparkling in the sunlight, as if proclaiming the glory of the Divine Warrior Clan.
+- **Ironblood Village**: The Ironblood Villages are scattered around the War God Plains, primarily inhabited by Divine Warriors engaged in daily training and their families. These villages are robustly constructed to withstand potential accidental impacts during training. The villages are equipped with comprehensive training and living facilities, providing a safe and convenient living environment for the Divine Warriors.
+The houses in the village are mostly built of sturdy stone and metal, presenting an ancient and resilient style. Each village has a central square equipped with various training apparatuses for the Divine Warriors to use at any time. The villages are surrounded by high protective walls, inscribed with defensive runes, capable of repelling any external threats.
+- **Weapons Forge Area**: The Weapons Forge Area is located in the western part of War God Star, a specialized area dedicated to the manufacture and testing of new weapons. Here, the finest blacksmiths and weapon masters from across the universe gather to continuously provide the Divine Warriors with the most advanced combat equipment. The forge area is filled with the sound of flames and metal clashing, and the air is thick with the scent of iron and fire.
+The forge area houses hundreds of furnaces, each accompanied by a massive anvil and various forging tools. Blacksmiths wield enormous hammers, shaping the red-hot metal. Fiery dragons of flame spew from the furnaces, illuminating the entire area. Whenever a new weapon is born, the blacksmiths inscribe mysterious runes onto it, bestowing it with special powers.
 
 
 
 ## 戰神星
-戰神星是一個布滿戰場和競技場的星球，適合神鬥士族的戰鬥訓練和武力測試。神鬥士族在這裡進行戰鬥的修煉，星球中心有一座巨大的戰神神殿，是神鬥士族匯聚和決策的中心。
+戰神星是神諭星域中的四大星球之一，以其充满战斗与武力测试的环境闻名于世。这个星球是神斗士族的主要训练场和居住地，但也吸引了男神族和女神族前来进行各种武力修炼和精神修行。戰神星不仅是战斗技巧的熔炉，也是神灵们展示力量和荣耀的舞台。与其他三个星球（命運之輪星、隱秘之源星、歸墟星）相比，戰神星更强调实战和武力，而其他星球则分别侧重于命运解析、神秘探索和灵魂归宿。
+在神諭星域的远古时代，男神族、女神族和神斗士族共同抵御了来自虚空中的黑暗势力。在那场史诗般的战斗中，戰神星成为了战斗的核心战场。传说男神族的战神阿瑞斯和女神族的战神雅典娜联合神斗士族的领袖雷奥，最终击败了黑暗势力，保护了神諭星域的和平。为了纪念这场伟大的胜利，三族决定将戰神星作为永恒的训练场和战争的圣地。
 
 ### 戰神平原
-戰神平原是戰神星上最廣闊的地帶，這裡布滿了用於訓練和實戰演練的戰場。平原上的地形多變，從裂谷到山丘，為神鬥士提供多樣化的訓練環境。此地經常舉辦大規模的戰鬥模擬，吸引眾多神鬥士前來磨練技藝。
+戰神平原是戰神星上最广阔的区域，这里遍布着各种用于训练和实战演练的战场。平原上的地形千变万化，从深邃的裂谷到高耸的山丘，为神斗士们提供了丰富多样的训练环境。传说中，男神族和女神族的战神们在这里留下了无数的战斗痕迹，每一块岩石和每一道河流都见证了他们的英勇和智慧。
+在戰神平原的中央，有一片巨大的战场，地面上刻满了古老的符文，这些符文据说是战神们在战斗中使用的咒语。每当月光照耀，这些符文会散发出微弱的光芒，仿佛在诉说着那些久远的故事。四周的山丘上，矗立着战神们的雕像，仿佛在守护着这片神圣的土地。
 
 ### 永恆競技場
-位於星球的中心位置，是一座龐大的露天競技場，可容納萬人觀戰。競技場是各種重要戰鬥和比賽的舉辦地，包括年度神鬥士錦標賽和戰神儀式。
+永恆競技場位于战神星的中心，是一座巨大的露天竞技场，可以容纳数万观众。这里是各种重要战斗和比赛的举办地，包括年度神斗士锦标赛和战神仪式。每年，各族的战士们都会聚集在这里，展示他们的战斗技巧和力量。
+竞技场的中央是一片巨大的沙地，四周环绕着高耸的看台。每当比赛开始，观众们会在看台上欢呼雀跃，整个竞技场充满了紧张与激动的气氛。竞技场的墙壁上镶嵌着数不清的宝石，这些宝石在阳光的照耀下闪闪发光，仿佛在为每一场战斗增添神秘的力量。
 
 ### 戰神神殿
-競技場旁邊建有戰神神殿，這是神鬥士族的精神和指揮中心。神殿內部裝飾著歷代戰神的雕像和壁畫，記錄著戰鬥的歷史和榮譽。
+战神神殿位于永恒竞技场旁边，是神斗士族的精神和指挥中心。神殿内部装饰着历代战神的雕像和壁画，记录着战斗的历史和荣誉。这里也是神斗士族进行重大决策和祭祀仪式的地方。
+神殿的内部宽敞而神圣，中央是一座巨大的祭坛，上面刻满了古老的符文和战神的象征。四周的墙壁上绘有战神们的英雄事迹，每一幅壁画都栩栩如生，展现了战神们的勇气和智慧。神殿的穹顶是由纯金打造的，在阳光的照射下闪闪发光，仿佛在昭示着神斗士族的荣耀。
 
 ### 鐵血村落
-散布在戰神平原周圍的小村落，主要由參與日常訓練的神鬥士及其家屬居住。這些村落建造堅固，能夠抵禦訓練中可能發生的意外衝擊。
+铁血村落散布在战神平原的周围，主要由参与日常训练的神斗士及其家属居住。这些村落建造坚固，能够抵御训练中可能发生的意外冲击。村落中有着完善的训练设施和生活设施，为神斗士们提供了一个安全和便利的居住环境。
+村落的房屋大多由坚固的石材和金属建造，呈现出一种古朴而坚韧的风格。每个村落都有一个中心广场，广场上设有各种训练器材，供神斗士们随时使用。村落四周环绕着高高的防护墙，墙上布满了防御符文，能够抵御任何外来的威胁。
 
 ### 武器熔爐區
-在戰神星的西部，有一片專門用於製造和試驗新型武器的熔爐區。這裡聚集了宇宙中最優秀的鐵匠和武器大師，不斷為神鬥士們提供最先進的戰鬥裝備。
+武器熔炉区位于战神星的西部，是一个专门用来制造和试验新型武器的区域。这里聚集了宇宙中最优秀的铁匠和武器大师，他们不断为神斗士们提供最先进的战斗装备。熔炉区内充满了火焰和金属的碰撞声，空气中弥漫着铁与火的气息。
+熔炉区内有数百座熔炉，每座熔炉旁都有一个巨大的铁砧和各种锻造工具。铁匠们挥舞着巨大的铁锤，将炽热的金属锤打成形。一条条火龙从熔炉中喷出，照亮了整个区域。每当一件新的武器诞生，铁匠们会在武器上刻下神秘的符文，为其赋予特殊的力量。


### PR DESCRIPTION
War God Star is one of the four major planets in the Oracle Realm, renowned for its environment brimming with combat and martial testing. This planet serves as the primary training ground and residence for the Divine Warrior Clan, but it also attracts Male Gods and Goddesses for various martial training and spiritual cultivation. War God Star is not only a forge for combat skills but also a stage where deities display their power and glory. Compared to the other three planets (Destiny Wheel Star, Veiled Origin Star, Sanctuary of Return), War God Star emphasizes practical combat and martial prowess, while the other planets focus on destiny analysis, mysterious exploration, and soul restoration, respectively. 戰神星是神諭星域中的四大星球之一，以其充满战斗与武力测试的环境闻名于世。这个星球是神斗士族的主要训练场和居住地，但也吸引了男神族和女神族前来进行各种武力修炼和精神修行。戰神星不仅是战斗技巧的熔炉，也是神灵们展示力量和荣耀的舞台。与其他三个星球（命運之輪星、隱秘之源星、歸墟星）相比，戰神星更强调实战和武力，而其他星球则分别侧重于命运解析、神秘探索和灵魂归宿。